### PR TITLE
Fix JSON linting configuration and cursor settings

### DIFF
--- a/btop/btop.conf
+++ b/btop/btop.conf
@@ -1,4 +1,4 @@
-#? Config file for btop v. 1.4.0
+#? Config file for btop v. 1.4.4
 
 #* Name of a btop++/bpytop/bashtop formatted ".theme" file, "Default" and "TTY" for builtin themes.
 #* Themes should be placed in "../share/btop/themes" relative to binary or "$HOME/.config/btop/themes"
@@ -47,7 +47,7 @@ graph_symbol_net = "default"
 graph_symbol_proc = "default"
 
 #* Manually set which boxes to show. Available values are "cpu mem net proc" and "gpu0" through "gpu5", separate values with whitespace.
-shown_boxes = "cpu mem net proc"
+shown_boxes = "mem proc net cpu"
 
 #* Update time in milliseconds, recommended 2000 ms or above for better sample times for graphs.
 update_ms = 1000
@@ -144,7 +144,7 @@ background_update = True
 custom_cpu_name = ""
 
 #* Optional filter for shown disks, should be full path of a mountpoint, separate multiple values with whitespace " ".
-#* Begin line with "exclude=" to change to exclude filter, otherwise defaults to "most include" filter. Example: disks_filter="exclude=/boot /home/user".
+#* Only disks matching the filter will be shown. Prepend exclude= to only show disks not matching the filter. Examples: disk_filter="/boot /home/user", disks_filter="exclude=/boot /home/user"
 disks_filter = ""
 
 #* Show graphs instead of meters for memory values.
@@ -203,6 +203,9 @@ net_sync = True
 
 #* Starts with the Network Interface specified here.
 net_iface = ""
+
+#* "True" shows bitrates in base 10 (Kbps, Mbps). "False" shows bitrates in binary sizes (Kibps, Mibps, etc.). "Auto" uses base_10_sizes.
+base_10_bitrate = "Auto"
 
 #* Show battery stats in top right if battery is present.
 show_battery = True

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -1,6 +1,6 @@
 # vim:fileencoding=utf-8:foldmethod=marker
 
-#: Fonts {{{
+ #: Fonts {{{
 
 #: kitty has very powerful font management. You can configure
 #: individual font faces and even specify special fonts for particular
@@ -24,7 +24,7 @@
 #:     italic_font      Operator Mono Book Italic
 #:     bold_italic_font Operator Mono Medium Italic
 
-font_size 20.0
+font_size 26.0
 
 #: Font size (in pts).
 
@@ -301,11 +301,11 @@ font_size 20.0
 #: Stop blinking cursor after the specified number of seconds of
 #: keyboard inactivity. Set to zero to never stop blinking.
 
-#: }}}
+# : }}}
 
-#: Scrollback {{{
+#:  Scrollback {{{
 
-# scrollback_lines 2000
+scrollback_lines 2000000
 
 #: Number of lines of history to keep in memory for scrolling back.
 #: Memory is allocated on demand. Negative numbers are (effectively)
@@ -690,11 +690,11 @@ font_size 20.0
 #::  Requires shell integration
 #::  <https://sw.kovidgoyal.net/kitty/shell-integration/> to work.
 
-#: }}}
+#: }}} 
 
-#: }}}
+#: }}} 
 
-#: Performance tuning {{{
+#: Perf ormance tuning {{{
 
 # repaint_delay 10
 
@@ -781,9 +781,9 @@ font_size 20.0
 #: be removed if Linux ever provides desktop-agnostic support for
 #: setting system sound themes.
 
-#: }}}
+#: }}} 
 
-#: Window layout {{{
+#: Wind ow layout {{{
 
 # remember_window_size  yes
 # initial_window_width  640
@@ -1128,9 +1128,9 @@ font_size 20.0
 #: margins the default color is chosen to match the background color
 #: of the neighboring tab.
 
-#: }}}
+#: }}} 
 
-#: Color scheme {{{
+#: Colo r scheme {{{
 
 # foreground #dddddd
 # background #000000
@@ -1297,11 +1297,11 @@ font_size 20.0
 
 #: Color for marks of type 3 (violet)
 
-#: }}}
+#: }}} 
 
 #: }}}
 
-#: Advanced {{{
+#: Adva nced {{{
 
 # shell .
 
@@ -1779,9 +1779,9 @@ font_size 20.0
 #: Changing this option by reloading the config is not supported, it
 #: will not have any effect.
 
-#: }}}
+#: }}} 
 
-#: Keyboard shortcuts {{{
+#: Keyb oard shortcuts {{{
 
 #: Keys are identified simply by their lowercase Unicode characters.
 #: For example: a for the A key, [ for the left square bracket key,
@@ -1847,7 +1847,7 @@ font_size 20.0
 #: cause all invocations of the hints kitten to have the --hints-
 #: offset=0 option applied.
 
-#: Clipboard {{{
+#: Clipb oard {{{
 
 #: Copy to clipboard
 
@@ -1979,9 +1979,9 @@ font_size 20.0
 #::  Requires shell integration
 #::  <https://sw.kovidgoyal.net/kitty/shell-integration/> to work.
 
-#: }}}
+#: }}} 
 
-#: Window management {{{
+#: Wind ow management {{{
 
 #: New window
 
@@ -2175,9 +2175,9 @@ font_size 20.0
 #: rather than at the end of the tabs list, use::
 
 #:     map ctrl+t new_tab !neighbor [optional cmd to run]
-#: }}}
+#: }}} 
 
-#: Layout management {{{
+#: Layo ut management {{{
 
 #: Next layout
 
@@ -2236,7 +2236,7 @@ font_size 20.0
 #: size::
 
 #:     map kitty_mod+f6 change_font_size current 10.0
-#: }}}
+#: }}} 
 
 #: Select and act on visible text {{{
 
@@ -2304,9 +2304,9 @@ font_size 20.0
 #: The hints kitten has many more modes of operation that you can map
 #: to different shortcuts. For a full description see hints kitten
 #: <https://sw.kovidgoyal.net/kitty/kittens/hints/>.
-#: }}}
+#: }}} 
 
-#: Miscellaneous {{{
+#: Misc ellaneous {{{
 
 #: Show documentation
 

--- a/nvim/lua/bryan/plugins/linting.lua
+++ b/nvim/lua/bryan/plugins/linting.lua
@@ -447,6 +447,7 @@ return {
 
       -- JSON
       jsonlint = {
+        cmd = "jsonlint",
         args = {
           "--max-line-length=130",
         },


### PR DESCRIPTION
This PR includes: 1) Fixed nvim-lint jsonlint configuration by adding missing cmd field 2) Fixed cursor-settings.json file that had duplicate JSON objects causing syntax errors 3) Updated various configuration files for kitty, btop, and lazygit