### PR TITLE
feat(nvim): add render-markdown.nvim for enhanced markdown viewing

### DIFF
--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -44,6 +44,7 @@
   "onedark.vim": { "branch": "main", "commit": "47bec7a6196a843dad195d2666c3ac84c6e80c78" },
   "oxocarbon.nvim": { "branch": "main", "commit": "cf49e389c22dab56224e43ae16422ddcd5b61b28" },
   "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
+  "render-markdown.nvim": { "branch": "main", "commit": "f422cb5c6855f150e2ddcfaf44e7157b98b34f6a" },
   "substitute.nvim": { "branch": "main", "commit": "0d2077398552f069abccbd964a26dd7cd26882cd" },
   "telescope-fzf-native.nvim": { "branch": "main", "commit": "b25b749b9db64d375d782094e2b9dce53ad53a40" },
   "telescope.nvim": { "branch": "0.1.x", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" },

--- a/nvim/lua/bryan/plugins/render-markdown.lua
+++ b/nvim/lua/bryan/plugins/render-markdown.lua
@@ -1,0 +1,11 @@
+return {
+  "MeanderingProgrammer/render-markdown.nvim",
+  dependencies = {
+    "nvim-treesitter/nvim-treesitter",
+    "echasnovski/mini.icons",
+  },
+  ft = { "markdown" },
+  ---@module 'render-markdown'
+  ---@type render.md.UserConfig
+  opts = {},
+}

--- a/nvim/test/render-markdown-test.md
+++ b/nvim/test/render-markdown-test.md
@@ -1,0 +1,40 @@
+# Render Markdown Test
+
+Use this file to verify `render-markdown.nvim` is working.
+
+## Text formatting
+
+This paragraph has **bold text**, *italic text*, and `inline code`.
+
+## Lists
+
+- [ ] Unchecked task
+- [x] Checked task
+- Regular bullet item
+
+1. Numbered item one
+2. Numbered item two
+
+## Code block
+
+```lua
+local function hello(name)
+  print("Hello, " .. name)
+end
+```
+
+## Table
+
+| Plugin | Purpose |
+| ------ | ------- |
+| treesitter | parsing |
+| render-markdown | preview |
+
+## Callout
+
+> [!NOTE]
+> If headings, checkboxes, and code blocks render cleanly, the plugin is working.
+
+## Link
+
+[render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim)


### PR DESCRIPTION
## Summary
- Add `render-markdown.nvim` with `nvim-treesitter` and `mini.icons` dependencies for rendered markdown in Neovim
- Load the plugin automatically on `markdown` filetypes
- Include a local test fixture at `nvim/test/render-markdown-test.md` for manual verification

## Test plan
- [x] `nvim ~/.config/nvim/test/render-markdown-test.md` renders headings, checkboxes, code blocks, tables, and callouts
- [x] `:RenderMarkdown get` reports enabled
- [x] `:RenderMarkdown toggle` switches between raw and rendered views
- [x] Merge after review


Made with [Cursor](https://cursor.com)